### PR TITLE
change range() bounds in chapter 5

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -339,7 +339,7 @@ Anyway, we need a different function:
 
 ~~~ {.rust}
     fn main() {
-        for num in range(1, 3) {
+        for num in range(1, 4) {
             println(num)
         }
     }
@@ -361,7 +361,7 @@ this. The first is to use the `to_str` function:
 
 ~~~ {.rust}
     fn main() {
-        for num in range(1, 3) {
+        for num in range(1, 4) {
             println(num.to_str())
         }
     }
@@ -385,7 +385,7 @@ is:
 
 ~~~ {.rust}
     fn main() {
-      for num in range(1, 3) {
+      for num in range(1, 4) {
         println(fmt!("%d", num));
       }
     }


### PR DESCRIPTION
Changed the range(1, 3) examples to range(1, 4). The example output matches range(1, 4), and changing it this way feels better than having the loop only go through 1 and 2.
