### PR TITLE
remove first instance of from_child.send(0) in ch6

### DIFF
--- a/book/chapter-06.md
+++ b/book/chapter-06.md
@@ -135,7 +135,6 @@ this: `DuplexStream`:
         from_child.try_send(23);
         from_child.send(24);
         from_child.send(25);
-        from_child.send(0);
 
         do 4.times {
             let answer = from_child.recv();


### PR DESCRIPTION
The first listing of the DuplexStream example in ch6 has `from_child.send(0)`, but it then disappears in the next listing of main(). Should probably not appear until the reason for it is explained.
