### PR TITLE
Call out "no debug symbols" warning as safe to ignore.

### DIFF
--- a/book/chapter-03.md
+++ b/book/chapter-03.md
@@ -30,7 +30,16 @@ this:
                    ^~~~~~~
 
 This happened when I left off the curly brace after the `main` function
-above. To run your program, do the Usual UNIX Thing:
+above. 
+
+This isn't an error:
+
+    $ rustc hello.rs
+    warning: no debug symbols in executable (-arch x86_64)
+    
+It happens on OSX for some versions of Rust. You can safely ignore it.
+
+To run your program, do the Usual UNIX Thing:
 
     $ ./hello
 


### PR DESCRIPTION
It's pretty confusing to get this error on the very first use of Rust, so it may be good to reassure people that it isn't a problem.
