### PR TITLE
Add section on using a built library without installing

### DIFF
--- a/book/chapter-12.md
+++ b/book/chapter-12.md
@@ -182,6 +182,14 @@ You'll also notice that `src/hello/lib.rs` turned into
 `libhello-ed8619dad9ce7d58-0.1.0.so`. This is a simple combination of the
 library name, a hash of its content, and the version.
 
+Now you can compile and run any program that uses `extern mod hello` like this:
+
+~~~ {.notrust}
+$ cd ~/src/foo
+$ rustc -L ~/src/hello/build/x86_64-unknown-linux-gnu/hello/ foo.rs
+$ ./foo
+~~~
+
 Now that your library builds, you'll want to commit:
 
 ~~~ {.notrust}


### PR DESCRIPTION
I really don't know if you want to include anything like this, or if this is the right place to put it, but for me, this would have been nice to have. You discuss how `rustpkg build` works and what goes into the `build` directory works, but not what you might want to do with that stuff. I think it's a good deal lower barrier to entry to be able to play around with building a library locally, than to push out a whole repository. If I knew how to use `rustpkg install` to install a package without a remote URL, I think that would be a better way to do this, but I haven't been able to figure that out.
