### PR TITLE
FIX: updated (last?) occurrence pre-0.8 for-syntax

### DIFF
--- a/book/chapter-10.md
+++ b/book/chapter-10.md
@@ -128,7 +128,7 @@ same... Let's fix that:
 
 ~~~ {.rust}
     fn print_vec<T>(v: &[T]) {
-        for v.iter().advance |&i| {
+        for i in v.iter() {
             println(i.to_str())
         }
     }


### PR DESCRIPTION
Found a small oversight of one instance of old for-syntax and fixed it.
