### PR TITLE
add example invocation of fmt! for struct in chapter 8

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -376,18 +376,18 @@ Awesome. Let's run it:
 
 Bam! Whew. We had to fight with the compiler a bit, and the errors
 weren't great, but that wasn't too bad. The other way to do it is to use
-the `fmt!` function. At least, it looks like a function to me. Here it
+the `format!` function. At least, it looks like a function to me. Here it
 is:
 
 ~~~ {.rust}
     fn main() {
       for num in range(1, 4) {
-        println(fmt!("%d", num));
+        println(format!("{:d}", num));
       }
     }
 ~~~
 
-`fmt!` is similar to `str % arg`, or the `format` and `sprintf`
+`format!` is similar to `str % arg`, or the `format` and `sprintf`
 functions in `Kernel`: it takes a format string, some arguments, and
 makes a string out of them. A cool feature of rust that sets it apart
 from C or C++, which also have this, is that the format strings are

--- a/book/chapter-08.md
+++ b/book/chapter-08.md
@@ -33,11 +33,11 @@ This gives:
     10
     20
 
-Seems simple enough! Note that you can give a struct to `fmt!`, using
-the `%?` format specifier, such as:
+Seems simple enough! Note that you can give a struct to `format!`, using
+the `:?` format specifier, such as:
 
 ~~~ {.rust}
-    println(fmt!("%?", m));
+    println(format!("{:?}", m));
 ~~~
 
 Which produces:
@@ -63,7 +63,7 @@ Let's add a method for our `Monster` s:
 
     impl Monster {
         fn attack(&self) {
-            println(fmt!("The monster attacks for %d damage.", self.attack));
+            println(format!("The monster attacks for {:d} damage.", self.attack));
         }
     }
 
@@ -93,7 +93,7 @@ methods, in Java) as well:
 
     impl Monster {
         fn attack(&self) {
-            println(fmt!("The monster attacks for %d damage.", self.attack));
+            println(format!("The monster attacks for {:d} damage.", self.attack));
         }
 
         fn count() {
@@ -123,7 +123,7 @@ Constructors are a good reason to use associated functions:
         }
 
         fn attack(&self) {
-            println(fmt!("The monster attacks for %d damage.", self.attack));
+            println(format!("The monster attacks for {:d} damage.", self.attack));
         }
 
         fn count() {
@@ -161,8 +161,8 @@ better idea. Here's an enum:
     impl Monster {
         fn attack(&self) {
           match *self {
-              ScubaArgentine(l, s, c, w) => println(fmt!("The monster attacks for %d damage.", w)),
-              IndustrialRaverMonkey(l, s, c, w) => println(fmt!("The monster attacks for %d damage.", w))
+              ScubaArgentine(l, s, c, w) => println(format!("The monster attacks for {:d} damage.", w)),
+              IndustrialRaverMonkey(l, s, c, w) => println(format!("The monster attacks for {:d} damage.", w))
           }
         }
     }
@@ -217,7 +217,7 @@ Neat. The cool thing is that when pattern matching on a struct, the
 
 ~~~ {.rust}
     match p {
-        Point(x, y) => println(fmt!("X: %d, Y: %d", x, y))
+        Point(x, y) => println(format!("X: {:d}, Y: {:d}", x, y))
     }
 ~~~
 

--- a/book/chapter-09.md
+++ b/book/chapter-09.md
@@ -21,7 +21,7 @@ See if this looks familliar:
 
         let our_favorite_numbers = your_favorite_numbers + my_favorite_numbers;
 
-        println(fmt!("The third favorite number is %d.", our_favorite_numbers[2]))
+        println(format!("The third favorite number is {:d}.", our_favorite_numbers[2]))
     }
 ~~~
 
@@ -48,7 +48,7 @@ You can mutate vectors if you make them so:
         let mut another_vector = ~[];
         another_vector.push_all(a_vector);
 
-        println(fmt!("The first number is %d.", another_vector[0]))
+        println(format!("The first number is {:d}.", another_vector[0]))
     }
 ~~~
 
@@ -59,7 +59,7 @@ Of course, changing an element of a vector doesn't make sense:
         let a_vector = ~[1,2,3];
         a_vector[0] = 5; // fizzbuzz.rs:3:2: 3:12 error: cannot assign to immutable vec content
 
-        println(fmt!("The first number is %d.", a_vector[0]))
+        println(format!("The first number is {:d}.", a_vector[0]))
     }
 ~~~
 
@@ -71,7 +71,7 @@ But you can move it to a mutable one and then change it:
         let mut mut_vector = a_vector;
         mut_vector[0] = 5;
 
-        println(fmt!("The first number is %d.", mut_vector[0]))
+        println(format!("The first number is {:d}.", mut_vector[0]))
     }
 ~~~
 

--- a/book/chapter-10.md
+++ b/book/chapter-10.md
@@ -533,7 +533,7 @@ make one:
 
     impl Monster for IndustrialRaverMonkey {
         fn attack(&self) {
-            println(fmt!("The monkey attacks for %d.", self.strength))
+            println(format!("The monkey attacks for {:d}.", self.strength))
         }
     }
 
@@ -550,8 +550,8 @@ Now we're cooking with gas! Remember our old implementation?:
     impl Monster {
         fn attack(&self) {
             match *self {
-                ScubaArgentine(l, s, c, w) => println(fmt!("The monster attacks for %d damage.", w)),
-                IndustrialRaverMonkey(l, s, c, w) => println(fmt!("The monster attacks for %d damage.", w))
+                ScubaArgentine(l, s, c, w) => println(format!("The monster attacks for {:d} damage.", w)),
+                IndustrialRaverMonkey(l, s, c, w) => println(format!("The monster attacks for {:d} damage.", w))
             }
         }
     }
@@ -571,13 +571,13 @@ implementation for absolutely anything:
 
     impl Monster for IndustrialRaverMonkey {
         fn attack(&self) {
-            println(fmt!("The monkey attacks for %d.", self.strength))
+            println(format!("The monkey attacks for {:d}.", self.strength))
         }
     }
 
     impl Monster for int {
         fn attack(&self) {
-            println(fmt!("The int attacks for %d.", *self))
+            println(format!("The int attacks for {:d}.", *self))
         }
     }
 
@@ -660,7 +660,7 @@ Done? Here's mine:
 
     impl Monster for IndustrialRaverMonkey {
         fn attack(&self) {
-            println(fmt!("The monkey attacks for %d.", self.strength))
+            println(format!("The monkey attacks for {:d}.", self.strength))
         }
 
         fn new() -> IndustrialRaverMonkey {
@@ -670,7 +670,7 @@ Done? Here's mine:
 
     impl Monster for DwarvenAngel {
         fn attack(&self) {
-            println(fmt!("The angel attacks for %d.", self.strength))
+            println(format!("The angel attacks for {:d}.", self.strength))
         }
         fn new() -> DwarvenAngel {
             DwarvenAngel {life: 540, strength: 6, charisma: 144, weapon: 50}
@@ -679,7 +679,7 @@ Done? Here's mine:
 
     impl Monster for AssistantViceTentacleAndOmbudsman {
         fn attack(&self) {
-            println(fmt!("The tentacle attacks for %d.", self.strength))
+            println(format!("The tentacle attacks for {:d}.", self.strength))
         }
         fn new() -> AssistantViceTentacleAndOmbudsman {
             AssistantViceTentacleAndOmbudsman {life: 320, strength: 6, charisma: 144, weapon: 50}
@@ -688,7 +688,7 @@ Done? Here's mine:
 
     impl Monster for TeethDeer {
         fn attack(&self) {
-            println(fmt!("The deer attacks for %d.", self.strength))
+            println(format!("The deer attacks for {:d}.", self.strength))
         }
         fn new() -> TeethDeer {
             TeethDeer {life: 655, strength: 192, charisma: 19, weapon: 109}
@@ -697,7 +697,7 @@ Done? Here's mine:
 
     impl Monster for IntrepidDecomposedCyclist {
         fn attack(&self) {
-            println(fmt!("The cyclist attacks for %d.", self.strength))
+            println(format!("The cyclist attacks for {:d}.", self.strength))
         }
         fn new() -> IntrepidDecomposedCyclist {
             IntrepidDecomposedCyclist {life: 901, strength: 560, charisma: 422, weapon: 105}
@@ -706,7 +706,7 @@ Done? Here's mine:
 
     impl Monster for Dragon {
         fn attack(&self) {
-            println(fmt!("The dragon attacks for %d.", self.strength))
+            println(format!("The dragon attacks for {:d}.", self.strength))
         }
         fn new() -> Dragon {
             Dragon {life: 1340, strength: 451, charisma: 1020, weapon: 939}

--- a/book/chapter-11.md
+++ b/book/chapter-11.md
@@ -304,7 +304,7 @@ on IRC, 'strcat' gave me this version:
     }
 
     fn process_guess(secret:int, guess: int) -> bool {
-        println(fmt!("You guessed: %d", guess));
+        println(format!("You guessed: {:d}", guess));
 
         if guess > secret {
             println("Your guess was too high!");
@@ -326,7 +326,7 @@ on IRC, 'strcat' gave me this version:
         println("Guess a number from 1-100 (you get five tries):");
 
         for round in range(0, 5) {
-            println(fmt!("Guess #%d", round));
+            println(format!("Guess \\#{:d}", round));
 
             let input = io::stdin().read_line();
 


### PR DESCRIPTION
Chapter 8 mentions using `fmt!` to print a struct, and gives example output, but not an example invocation. `fmt!` was already introduced in ch 5, but there's a lot of info packed into 6 and 7, so I think it's probably a good idea to reestablish it.

side note: my understanding from the 0.8 release note is that the new `format!` will eventually replace `fmt!`; do you think these should be changed to use it instead?
