### PR TITLE
elaborate on default case for match

### DIFF
--- a/book/chapter-08.md
+++ b/book/chapter-08.md
@@ -206,8 +206,16 @@ powerful. If we leave off the `_` case, Rust will complain:
     match.rs:6     }
     error: aborting due to previous error
 
-Neat. The cool thing is that when pattern matching on a struct, the
-`match` can destructure it:
+Neat. The reason we didn't need to specify a `_` case in our monster code
+is that because we were matching an `enum`, rust knew we had covered all
+the possible cases. But since we're matching an `int`, what would happen
+if we called, say, `message(349)`? Rust makes us specify a default case
+with `_` so that it knows exactly what we want. Make sure you put that
+`_` case _last_, however, because Rust looks at them top-to-bottom, and
+will take the first matching case it finds.
+
+The cool thing is that when pattern matching on a struct, the `match`
+can destructure it:
 
 ~~~ {.rust}
     match p {


### PR DESCRIPTION
Explains a bit more about the `_` case; why it wasn't necessary for the enum, and the importance of its order in the match.
