### PR TITLE
Chpt 5 - Made syntax follow other examples

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -172,7 +172,7 @@ failed. Let's make both tests pass:
     }
 ~~~
 
-    $ rustc test fizzbuzz.rs
+    $ rust test fizzbuzz.rs
 
     running 2 tests
     test test_is_three_with_not_three ... ok


### PR DESCRIPTION
Changed 'rustc' to 'rust' to be in line with other examples in the chapter.
