### PR TITLE
updates API for random number generator in a range

### DIFF
--- a/book/chapter-11.md
+++ b/book/chapter-11.md
@@ -263,22 +263,10 @@ This will print out a different number each time you run it. But you'll
 get biiiiiiig numbers. If we want 1-100, of course we have to do this:
 
 ~~~ {.rust}
-	use std::rand;
+	use std::rand::Rng;
 
     fn main() {
-        let r = rand::rng().gen_int_range(0, 100);
-        println(r.to_str());
-    }
-~~~
-
-One issue with this: We can get negatives too. `abs` to the rescue!!!:
-
-~~~ {.rust}
-	use std::rand;
-    use std::num::abs;
-
-    fn main() {
-        let r: int = abs(rand::rng().gen_int_range(0, 100));
+        let r = std::rand::rng().gen_integer_range(1, 101);
         println(r.to_str());
     }
 ~~~


### PR DESCRIPTION
there is an API update for generating a number in a range
http://static.rust-lang.org/doc/master/std/rand/trait.Rng.html#method.gen_integer_range

I'm using the following rust compiler:

rustc --version
rustc 0.8
host: x86_64-apple-darwin

Maybe the wording needs a bit of change since it removes one example (the abs one). 
Anyway I thought that it would be nice to have the book updated since I had to chase this "bug" for a while.
