### PR TITLE
Typo chapter 05, rustc -> rust

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -172,7 +172,7 @@ failed. Let's make both tests pass:
     }
 ~~~
 
-    $ rustc test fizzbuzz.rs
+    $ rust test fizzbuzz.rs
 
     running 2 tests
     test test_is_three_with_not_three ... ok


### PR DESCRIPTION
Just a small typo in Chapter 5.

rustc should be rust in one of the examples.
