### PR TITLE
Add title to all in one and chapter HTML

### DIFF
--- a/book/template.html
+++ b/book/template.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
+  <title>Rust for Rubyists</title>
   <meta name="generator" content="pandoc">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Learn the Rust programming language">


### PR DESCRIPTION
Before, they had no title at all, e.g. see here:

http://www.rustforrubyists.com/book/book.html

Individual chapter pages could also include the chapter title, but that would be a bigger change.
