### PR TITLE
Fix for usage of managed boxes

### DIFF
--- a/code/07/pointers.rs
+++ b/code/07/pointers.rs
@@ -1,12 +1,14 @@
+use std::gc::Gc;
+
 fn plus_one(x: &int) -> int {
     *x + 1
 }
 
 fn main() {
-    let x = @10;
+    let x = Gc::new(10);
     let y = ~10;
 
-    println(plus_one(x).to_str());
+    println(plus_one(x.borrow()).to_str());
     println(plus_one(y).to_str());
 }
 


### PR DESCRIPTION
As per,

https://github.com/mozilla/rust/wiki/Doc-detailed-release-notes#09-january-2014

@ is deprecated.
