### PR TITLE
Fix incorrect syntax highlighting for Ruby block

### DIFF
--- a/book/chapter-01.md
+++ b/book/chapter-01.md
@@ -66,7 +66,7 @@ Here's a parallel "Hello World" in Rust:
 Here's a rough port to Ruby:
 
 
-~~~ {.rust}
+~~~ {.ruby}
     10.times do
       Thread.new do
         greeting_message = "Hello?"


### PR DESCRIPTION
Super minor--just something I noticed when perusing the markdown.
