### PR TITLE
fixed syntax error for pattern matching a struct

### DIFF
--- a/book/chapter-08.md
+++ b/book/chapter-08.md
@@ -219,7 +219,7 @@ can destructure it:
 
 ~~~ {.rust}
     match p {
-        Point(x, y) => println!("X: {:d}, Y: {:d}", x, y)
+        Point{x:x, y:y} => println!("X: {:d}, Y: {:d}", x, y)
     }
 ~~~
 


### PR DESCRIPTION
at least for Rust 0.9 this change seems to be necessary
