### PR TITLE
BUGFIX: in 0.9 `do` takes a proc not a closure

### DIFF
--- a/book/chapter-01.md
+++ b/book/chapter-01.md
@@ -54,12 +54,12 @@ Here's a parallel "Hello World" in Rust:
 
 ~~~ {.rust}
     fn main() {
-        10.times ( ||
+        for num in range(0, 10) {
             do spawn {
                 let greeting_message = "Hello?";
                 println(greeting_message);
             }
-        )
+        }
     }
 ~~~
 


### PR DESCRIPTION
The `do` syntax changed in 0.9, causing the code to fail with `last argument in `do` call has non-procedure type: ||`

The code now runs (but may not be idiomatic).
