### PR TITLE
Correct Ruby method reference to Object#to_s instead of Object#to_str

### DIFF
--- a/book/chapter-10.md
+++ b/book/chapter-10.md
@@ -204,7 +204,7 @@ most of it, it just works out. Think about this:
 ~~~
 
 We trust that this will always work, because `Object` implements
-`#to_str`. But if we had this:
+`#to_s`. But if we had this:
 
 ~~~ {.ruby}
     def print_each(arr)


### PR DESCRIPTION
Corrected the statement in chapter 10, where you say Ruby's `Object` class implements `#to_str` method, while `Object.instance_methods.include?(:to_str)` obviously returns `false`.
