### PR TITLE
Fix a typo in command

### DIFF
--- a/book/chapter-11.md
+++ b/book/chapter-11.md
@@ -174,10 +174,10 @@ it out to the screen.
 
 This gave an odd result:
 
-    $ make
-    rustc fizzbuzz.rs
-    5
+    $ rustc casting.rs && ./casting
     INPUT:
+    5
+    YOU TYPED:
     Some(5)
 
 


### PR DESCRIPTION
@steveklabnik It must've been copy-pasted that led to a typo, so here's the correction.
