### PR TITLE
Indentation and error message fixes

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -82,7 +82,7 @@ returned true. Now that we have a failing test, let's make it pass:
 
 ~~~ {.rust}
     fn is_three(num: int) -> bool {
-      return false;
+        return false;
     }
 
     #[test]
@@ -117,15 +117,15 @@ another test, and see what happens:
     #[test]
     fn test_is_three_with_not_three() {
         if is_three(1) {
-          fail!("One is not three");
+            fail!("One is not three");
         }
     }
 
     #[test]
     fn test_is_three_with_three() {
-      if !is_three(3) {
-        fail!("Three should be three");
-      }
+        if !is_three(3) {
+            fail!("Three should be three");
+        }
     }
 ~~~
 
@@ -345,9 +345,9 @@ is:
 
 ~~~ {.rust}
     fn main() {
-      for num in range(1, 4) {
-        println(format!("{:d}", num));
-      }
+        for num in range(1, 4) {
+            println(format!("{:d}", num));
+        }
     }
 ~~~
 
@@ -362,9 +362,9 @@ Because this combination is common, you can use `println!` as a combination of
 
 ~~~ {.rust}
     fn main() {
-      for num in range(1, 100) {
-        println!("{:d}", num);
-      }
+        for num in range(1, 100) {
+            println!("{:d}", num);
+        }
     }
 ~~~
 
@@ -497,10 +497,10 @@ Because the `if` returns a value, we could also do something like this:
     fn main() {
         for num in range(1, 101) {
             println(
-              if is_fifteen(num) { ~"FizzBuzz" }
-              else if is_three(num) { ~"Fizz" }
-              else if is_five(num) { ~"Buzz" }
-              else { num.to_str() }
+                if is_fifteen(num) { ~"FizzBuzz" }
+                else if is_three(num) { ~"Fizz" }
+                else if is_five(num) { ~"Buzz" }
+                else { num.to_str() }
             );
         }
     }
@@ -515,7 +515,7 @@ over again? Meet `assert!`:
 ~~~ {.rust}
     #[test]
     fn test_is_fifteen_with_fifteen() {
-      assert!(is_fifteen(15))
+        assert!(is_fifteen(15))
     }
 ~~~
 
@@ -526,7 +526,7 @@ such:
 
 ~~~ {.rust}
     fn main() {
-      assert!(1 == 0, "1 does not equal 0!");
+        assert!(1 == 0, "1 does not equal 0!");
     }
 ~~~
 

--- a/book/chapter-06.md
+++ b/book/chapter-06.md
@@ -208,22 +208,22 @@ this for now by telling our child to die:
     }
 
     fn main() {
-      let (from_child, to_child) = DuplexStream::new();
+        let (from_child, to_child) = DuplexStream::new();
 
-      do spawn {
-          plus_one(&to_child);
-      };
+        do spawn {
+            plus_one(&to_child);
+        };
 
-      from_child.send(22);
-      from_child.send(23);
-      from_child.send(24);
-      from_child.send(25);
-      from_child.send(0);
+        from_child.send(22);
+        from_child.send(23);
+        from_child.send(24);
+        from_child.send(25);
+        from_child.send(0);
 
-      for num in range(0, 4) {
-          let answer = from_child.recv();
-          println(answer.to_str());
-      }
+        for num in range(0, 4) {
+            let answer = from_child.recv();
+            println(answer.to_str());
+        }
     }
 ~~~
 
@@ -248,21 +248,21 @@ video game:
 ~~~ {.rust}
     fn main() {
 
-      do spawn {
-        player_handler();
-      }
+        do spawn {
+            player_handler();
+        }
 
-      do spawn {
-        world_handler();
-      }
+        do spawn {
+            world_handler();
+        }
 
-      do spawn {
-        rendering_handler();
-      }
+        do spawn {
+            rendering_handler();
+        }
 
-      do spawn {
-        io_handler();
-      }
+        do spawn {
+            io_handler();
+        }
     }
 ~~~
 

--- a/book/chapter-08.md
+++ b/book/chapter-08.md
@@ -20,10 +20,10 @@ Structs are ways of packaging up multiple values into one:
     }
 
     fn main() {
-      let m = Monster { health: 10, attack: 20 };
+        let m = Monster { health: 10, attack: 20 };
 
-      println(m.health.to_str());
-      println(m.attack.to_str());
+        println(m.health.to_str());
+        println(m.attack.to_str());
     }
 ~~~
 
@@ -154,10 +154,10 @@ better idea. Here's an enum:
 
     impl Monster {
         fn attack(&self) {
-          match *self {
-              ScubaArgentine(l, s, c, w) => println!("The monster attacks for {:d} damage.", w),
-              IndustrialRaverMonkey(l, s, c, w) => println!("The monster attacks for {:d} damage.", w)
-          }
+            match *self {
+                ScubaArgentine(l, s, c, w) => println!("The monster attacks for {:d} damage.", w),
+                IndustrialRaverMonkey(l, s, c, w) => println!("The monster attacks for {:d} damage.", w)
+            }
         }
     }
 
@@ -179,11 +179,11 @@ out. It's awesome. Here's a simpler match expression:
 
 ~~~ {.rust}
     fn message(i: int) {
-      match i {
-          1 => println("ONE!"),
-          2 => println("Two is a prime."),
-          3 => println("THREE!"),
-          _ => println("no idea what that is, boss")
+        match i {
+            1 => println("ONE!"),
+            2 => println("Two is a prime."),
+            3 => println("THREE!"),
+            _ => println("no idea what that is, boss")
         }
     }
 

--- a/book/chapter-10.md
+++ b/book/chapter-10.md
@@ -32,15 +32,15 @@ Done? I got this:
 
 ~~~ {.rust}
     fn print_vec(v: &[int]) {
-      for i in v.iter() {
-        println(i.to_str())
-      }
+        for i in v.iter() {
+            println(i.to_str())
+        }
     }
 
     fn main() {
-      let vec = [1,2,3];
+        let vec = [1,2,3];
 
-      print_vec(vec);
+        print_vec(vec);
     }
 ~~~
 
@@ -101,15 +101,15 @@ things to convert our arguments to a string. Here's the answer:
 
 ~~~ {.rust}
     fn print_vec(v: &[int]) {
-      for i in v.iter() {
-          println(i.to_str())
-      }
+        for i in v.iter() {
+            println(i.to_str())
+        }
     }
 
     fn print_vec_str(v: &[~str]) {
-      for i in v.iter() {
-          println((*i).to_str())
-      }
+        for i in v.iter() {
+            println((*i).to_str())
+        }
     }
 
     fn main() {
@@ -255,13 +255,13 @@ this out:
     }
 
     fn main() {
-      let vec = [1,2,3];
+        let vec = [1,2,3];
 
-      print_vec(vec);
+        print_vec(vec);
 
-      let str_vec = [~"hey", ~"there", ~"yo"];
+        let str_vec = [~"hey", ~"there", ~"yo"];
 
-      print_vec(str_vec);
+        print_vec(str_vec);
     }
 ~~~
 


### PR DESCRIPTION
These commits fix 2 issues:
- One of the compiler error messages does not correspond to the example code that supposedly generated it.
- Several rust code examples mix 2 and 4 space indentation styles.
