### PR TITLE
Spawn signature changed in 0.9

### DIFF
--- a/book/chapter-06.md
+++ b/book/chapter-06.md
@@ -56,7 +56,7 @@ of things aren't like that. Let's take a look at the type signature of
 `spawn`:
 
 ~~~ {.rust}
-    fn spawn(f: ~fn())
+    fn spawn(f: proc())
 ~~~
 
 Spawn is a function that takes a pointer to another function (it's a


### PR DESCRIPTION
Ok, lets try this again without the merge bubble...

The signature for spawn changed to fn spawn(f: proc()) in 0.9:

http://static.rust-lang.org/doc/0.9/std/task/fn.spawn.html
