### PR TITLE
Add a semicolon to remove confusion about why it was left out

### DIFF
--- a/book/chapter-04.md
+++ b/book/chapter-04.md
@@ -24,7 +24,7 @@ fails. Let's give it a shot: Open up `testing.rs` and put this in it:
 
     #[test]
     fn this_tests_code() {
-        println("")
+        println("");
     }
 ~~~
 


### PR DESCRIPTION
Chapter 1 says "`;` s everywhere. You don't always need them, but let's
put them in for now." Then chapter 5 (which is actually not long after
chapter 1), this example leaves the semicolon out.

This is before the explanation about semicolons and ignoring values of
expressions, and adding the semicolon here doesn't break anything,
so IMO this causes less cognitive distress on the reader to wonder why
you left the semicolon out.
