### PR TITLE
Make arguments to range consistent across examples

### DIFF
--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -247,7 +247,7 @@ out all the numbers from one to 100. It's easy!
     use std::io::println;
 
     fn main() {
-        for num in range(0,100) {
+        for num in range(1, 100) {
             println("num");
         }
     }
@@ -315,7 +315,7 @@ Anywho, where were we? Oh, iteration:
     use std::io::println;
 
     fn main() {
-        for num in range(0, 100) {
+        for num in range(1, 100) {
             println(num);
         }
     }
@@ -365,7 +365,7 @@ is:
     use std::io::println;
 
     fn main() {
-        for num in range(1, 4) {
+        for num in range(1, 100) {
             println(format!("{:d}", num));
         }
     }


### PR DESCRIPTION
When you're showing how to fix the `println` by using `.to_str()`, your
arguments to `range` have inexplicably changed from `(0, 100)` to `(1,
100)`. Then in your first `format!` example, the arguments are `(1, 4)`

I made all these be (1, 100); I could also see these being fixed by
being changed to (0, 100) and then changing them to (1, 101) when you
change 100 to 101 and talk about it.
