### PR TITLE
Don't change the print_vec implementation between `nm` runs

### DIFF
--- a/book/chapter-10.md
+++ b/book/chapter-10.md
@@ -316,9 +316,9 @@ this out:
     ....editing...
     $ cat traits.rs
 ~~~ {.rust}
-    fn print_vec<T: ToStr>(v: &[T]) {
+    fn print_vec<T: std::fmt::Show>(v: &[T]) {
         for i in v.iter() {
-            println((*i).to_str())
+            println!("{}", i)
         }
     }
 


### PR DESCRIPTION
I got confused when you were comparing the two calls to `nm` because the
code changed the signature and implementation of the print_vec function,
but was only trying to illustrate the change that happens because of the
invocation of print_vec on only integers, not strings too. So I think
print_vec should stay exactly the same to make the point clearer.
