### PR TITLE
Updating information about the current version of Rust on Homebrew.

### DIFF
--- a/book/chapter-02.md
+++ b/book/chapter-02.md
@@ -66,8 +66,8 @@ already use. Just do this:
 
 If you don't use Homebrew, install it. Seriously.
 
-(Note: If you're reading this close to release, Homebrew may not have 0.10 yet,
-you can use brew install --HEAD rust to get master, which will be close.)
+(Note: Homebrew's current version of rust is 0.10, but you can use `brew install --HEAD rust`
+to get the most recent version of rust.)
 
 As with all of Homebrew, this is a community-maintained package. Please review the contents
 of packages before totally trusting what's inside of them.


### PR DESCRIPTION
This is a minor change, but Homebrew is at 0.10 at this point.
