### PR TITLE
Update chapter-11.md

### DIFF
--- a/book/chapter-11.md
+++ b/book/chapter-11.md
@@ -32,7 +32,7 @@ fn main() {
     let input = reader.read_line().ok().expect("Failed to read line");
 
     println!("YOU TYPED:");
-    println!(input);
+    println!("{:s}", input);
 }
 ~~~
 


### PR DESCRIPTION
Fixes

```
error: format argument must be a string literal.
stdin.rs:10   println!(input);
                       ^~~~~
error: aborting due to previous error
```
