### PR TITLE
Make the Ruby example better reflect the Rust one

### DIFF
--- a/book/chapter-01.md
+++ b/book/chapter-01.md
@@ -67,7 +67,7 @@ Here's a rough port to Ruby:
 
 
 ~~~ {.ruby}
-    10.times do
+    10.times.map do
       Thread.new do
         greeting_message = "Hello?"
 
@@ -75,7 +75,7 @@ Here's a rough port to Ruby:
         # usage in the Rust example.
         puts "#{greeting_message}"
       end
-    end
+    end.each(&:join)
 ~~~
 
 That's it. Note the stuff that's *similar* to Ruby:

--- a/code/01/hello.rb
+++ b/code/01/hello.rb
@@ -1,6 +1,9 @@
-10.times do
+10.times.map do
   Thread.new do
     greeting_message = "Hello?"
-    puts "#{greeting_message}" # slightly unnatural ruby to match `format!` macro in rust.
+
+    # This is weird in Ruby but it's closer to the println! macro
+    # usage in the Rust example.
+    puts "#{greeting_message}"
   end
-end
+end.each(&:join)

--- a/code/01/hello.rs
+++ b/code/01/hello.rs
@@ -1,9 +1,8 @@
 fn main() {
-    for num in range(0, 10) {
+    for _ in range(0u, 10) {
         spawn(proc() {
             let greeting_message = "Hello?";
             println!("{}", greeting_message);
-            // or just `println!("Hello?")`
         });
     }
 }


### PR DESCRIPTION
Hello,

Ruby does not wait until all threads are done while Rust does. Would not it be more fair to account for this in the example given in the first chapter? One can also update the microbenchmark in that chapter reporting a much higher improvement over Ruby.

Regards,
Ivan
