### PR TITLE
Pass reference pointer not box pointer

### DIFF
--- a/book/chapter-07.md
+++ b/book/chapter-07.md
@@ -129,7 +129,7 @@ fn plus_one(x: &int) -> int {
 fn main() {
     let y = box 10i;
 
-    println!("{:d}", plus_one(y));
+    println!("{:d}", plus_one(&*y));
 }
 ~~~
 


### PR DESCRIPTION
This code sample triggers a compiler error as we are passing a box 
when `plus_one()` expects a reference.

Obviously, this is one of many ways to fix this problem. Another would be
to have `plus_one()` accept a `Box<int>`, but that would require altering
the text accompanying the code and is more than `plus_one()` needs.
