### PR TITLE
Change 'fail!' to 'panic!' in text and code

### DIFF
--- a/book/chapter-04.md
+++ b/book/chapter-04.md
@@ -48,7 +48,7 @@ Bam! Now let's make it fail:
 ~~~ {.rust}
 #[test]
 fn this_tests_code() {
-    fail!("Fail!");
+    panic!("Fail!");
 }
 ~~~
 

--- a/book/chapter-05.md
+++ b/book/chapter-05.md
@@ -20,7 +20,7 @@ First, a test. This will go in fizzbuzz.rs:
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 ~~~
@@ -45,7 +45,7 @@ fn div_by_three(num: int) -> bool {
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 ~~~
@@ -96,7 +96,7 @@ fn div_by_three(num: int) -> bool {
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 ~~~
@@ -125,14 +125,14 @@ fn div_by_three(num: int) -> bool {
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 
 #[test]
 fn test_div_by_three_with_three() {
     if !div_by_three(3) {
-        fail!("Three should be three");
+        panic!("Three should be three");
     }
 }
 ~~~
@@ -178,14 +178,14 @@ fn div_by_three(num: int) -> bool {
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 
 #[test]
 fn test_div_by_three_with_three() {
     if !div_by_three(3) {
-        fail!("Three should be three");
+        panic!("Three should be three");
     }
 }
 ~~~
@@ -485,7 +485,7 @@ fn main() {
 
 It's more compact, and removes the intermediate variable all together.
 
-We can do one other thing too: this whole `if/fail!` thing so common in
+We can do one other thing too: this whole `if/panic!` thing so common in
 tests seems too complex. Why do we have to write if over and over and
 over again? Meet `assert!`:
 

--- a/code/04/testing.rs
+++ b/code/04/testing.rs
@@ -1,4 +1,4 @@
 #[test] 
 fn this_tests_code() { 
-    fail!("Fail!");
+    panic!("Fail!");
 }

--- a/code/05/fizzbuzz.rs
+++ b/code/05/fizzbuzz.rs
@@ -25,42 +25,42 @@ fn div_by_fifteen(num: int) -> bool {
 #[test]
 fn test_div_by_three() {
     if div_by_three(1) {
-        fail!("One is not three");
+        panic!("One is not three");
     }
 }
 
 #[test]
 fn test_div_by_three_with_three() {
     if !div_by_three(3) {
-        fail!("Three should be three");
+        panic!("Three should be three");
     }
 }
 
 #[test]
 fn test_div_by_five() {
     if div_by_five(1) {
-        fail!("One is not five");
+        panic!("One is not five");
     }
 }
 
 #[test]
 fn test_div_by_five_with_five() {
     if !div_by_five(5) {
-        fail!("Five should be five");
+        panic!("Five should be five");
     }
 }
 
 #[test]
 fn test_div_by_fifteen() {
     if div_by_fifteen(1) {
-        fail!("One is not fifteen");
+        panic!("One is not fifteen");
     }
 }
 
 #[test]
 fn test_div_by_fifteen_with_fifteen() {
     if !div_by_fifteen(15) {
-        fail!("Fifteen should be fifteen");
+        panic!("Fifteen should be fifteen");
     }
 }
 


### PR DESCRIPTION
In accordance with https://github.com/rust-lang/rfcs/pull/221. This will prevent confusion for new Rust developers who follow the book and get compile errors when 'fail!' is used :confused: .

I left the 'Fail!' text in here because it seemed to be a description of what was happening, rather than a command:

``` rust
#[test]
fn this_tests_code() {
    panic!("Fail!");
}
```
