### PR TITLE
Enforce chapter sorting in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CHAPTERS=book/preamble.md \
-				 $(wildcard book/chapter-*.md)
+				 $(sort $(wildcard book/chapter-*.md))
 
 CONTENTS=book/title.txt \
 				 $(CHAPTERS)


### PR DESCRIPTION
When I built the PDF using GNU Make 3.82 the chapters were out of order. This small change fixes it.